### PR TITLE
Add a script to extract notabenoid cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The tool for grabbing Russian translation of [What If?][1] articles from
 
 ## Usage
 
-Get a cookies file in the Netscape compatible format. I’m using the [Cookies
-Manager+][3] addon for Firefox (and replace `%2F` in the PATH field with `/`,
-see [here][4]).
+Get a cookies file in the Netscape compatible format. Use an addon for your Web
+browser to extract the cookies file. You can use the `extract_cookies.sh`
+script from this repository for Firefox.
 
 Run the script:
 
@@ -24,9 +24,6 @@ and all translations of each fragment.
 
 A script `--all` output can be diff'ed with files produced by [What If?
 grabbing tool](https://github.com/whatifrussian/what_if_parse).
-
-[3]: https://addons.mozilla.org/en-US/firefox/addon/cookies-manager-plus/
-[4]: https://github.com/vanowm/FirefoxCookiesManagerPlus/issues/124
 
 ## License
 

--- a/extract_cookies.sh
+++ b/extract_cookies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# Based on https://gist.github.com/hackerb9/d382e09683a52dcac492ebcdaf1b79af
+
+# Firefox locks its sqlite file, let's copy it.
+cp ~/.mozilla/firefox/*/cookies.sqlite ./cookies.sqlite
+
+echo "# Netscape HTTP Cookie File" > cookies.txt
+sqlite3 -separator $'\t' cookies.sqlite >> cookies.txt <<- EOF
+	.mode tabs
+	.header off
+	select host,
+	case substr(host,1,1)='.' when 0 then 'FALSE' else 'TRUE' end,
+	path,
+	case isSecure when 0 then 'FALSE' else 'TRUE' end,
+	expiry,
+	name,
+	value
+	from moz_cookies
+	where host like "%notabenoid.org%";
+EOF
+
+rm cookies.sqlite


### PR DESCRIPTION
The Cookies Manager+ Firefox extension does not work anymore, see https://github.com/vanowm/FirefoxCookiesManagerPlus/issues/131.